### PR TITLE
hotfix: Fix mock provider default responses parameter (v0.2.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "persuader",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "description": "Session-based LLM orchestration with validation-driven retry loops and guaranteed schema-adhering output.",
   "main": "./dist/index.mjs",

--- a/src/core/runner/index.ts
+++ b/src/core/runner/index.ts
@@ -43,12 +43,16 @@ export {
 /**
  * Create a minimal mock provider for testing
  *
- * @param responses - Array of responses to return in sequence
+ * @param responses - Array of responses to return in sequence (defaults to valid JSON responses)
  * @param name - Provider name for identification
  * @returns Mock provider adapter
  */
 export function createMockProvider(
-  responses: string[],
+  responses: string[] = [
+    '{"message": "Hello from mock provider", "success": true, "timestamp": 1631234567890}',
+    '{"result": "Mock response", "status": "completed", "confidence": 0.95}',
+    '{"data": "Test data", "processed": true, "score": 8.5}',
+  ],
   name: string = 'mock-provider'
 ): ProviderAdapter {
   let callCount = 0;


### PR DESCRIPTION
## Summary
Fixes critical bug in `createMockProvider()` where calling without arguments caused runtime error: "Cannot read properties of undefined (reading 'length')".

## Problem
- Published v0.2.0 package had a breaking change in `createMockProvider()`
- Function required `responses` parameter but was designed to work without arguments
- Caused crashes when using mock provider for testing

## Solution
- Added default responses array parameter to maintain backward compatibility  
- Now `createMockProvider()` works without arguments as expected
- Provides sensible default mock responses for testing

## Changes
- **src/core/runner/index.ts**: Added default responses parameter with 3 sample JSON responses
- **package.json**: Bumped version to 0.2.1

## Test Results
✅ All 58 tests passing  
✅ Mock provider works without arguments  
✅ Mock provider works with custom responses  
✅ Full NPM package integration tested in PersuaderNpmTest  
✅ Backward compatibility maintained  

## Breaking Changes
None - this is a backward-compatible bug fix

## Notes
- This replaces PR #24 which had merge conflicts
- Clean branch based on latest main (v0.2.0)
- Ready for immediate merge and NPM publishing

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>