### PR TITLE
fix: ensure fresh Claude CLI sessions with explicit session ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] - 2025-10-31
+
+### Fixed
+- Claude CLI session reuse issue: Now passes explicit `--session-id` flag to ensure fresh sessions on each `initSession()` call, preventing stale rate limits and authentication errors from previous sessions
+
 ## [0.8.0] - 2024-01-24
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "persuader",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "type": "module",
   "description": "Session-based LLM orchestration with validation-driven retry loops and guaranteed schema-adhering output.",
   "main": "./dist/index.cjs",

--- a/src/adapters/claude-cli.ts
+++ b/src/adapters/claude-cli.ts
@@ -221,6 +221,9 @@ export class ClaudeCLIAdapter implements ProviderAdapter {
       // Use JSON output for structured parsing
       args.push('--output-format', 'json');
 
+      // Force specific session ID to ensure fresh session
+      args.push('--session-id', sessionId);
+
       // Add model if specified
       if (options.model) {
         args.push('--model', options.model);


### PR DESCRIPTION
## Problem

Claude CLI was reusing old session contexts even when `initSession()` was called to create a fresh session. This caused:
- Stale rate limit errors from previous sessions  
- Authentication errors carrying over between sessions
- Unexpected conversation context bleeding across operations

**Evidence from logs**:
```
sessionMatches: false  # Session ID generated by Persuader didn't match
numTurns: 22           # Claude CLI was continuing an old conversation
```

## Root Cause

Persuader generated a UUID for session tracking (line 197) but didn't pass it to Claude CLI via the `--session-id` flag. Claude CLI would then either:
1. Generate its own different UUID (causing ID mismatch)
2. Reuse an existing session (causing stale context)

## Solution

Pass Persuader's pre-generated UUID to Claude CLI via `--session-id` flag in `createSession()` method (line 225 in `src/adapters/claude-cli.ts`):

```typescript
args.push('--session-id', sessionId);
```

This ensures:
- ✅ Persuader controls the session ID (already generated via `randomUUID()` on line 197)
- ✅ Claude CLI uses the provided ID instead of generating its own
- ✅ Session IDs match between Persuader's tracking and Claude CLI's state  
- ✅ Each `initSession()` call creates a truly fresh session

## Impact

- **Type**: Bug fix (PATCH version: 0.8.1 → 0.8.2)
- **Breaking Changes**: None - public API unchanged
- **Backward Compatibility**: Fully compatible - transparent to users
- **Behavior**: Ensures fresh sessions, prevents context/auth bleeding

## Testing

✅ All tests pass (542 passed, 57 skipped)
✅ TypeScript validation passes  
✅ Linting passes (93 warnings, 0 errors)
✅ Build succeeds

## Files Changed

- `src/adapters/claude-cli.ts` - Added `--session-id` flag passing
- `package.json` - Version bump to 0.8.2
- `CHANGELOG.md` - Added fix entry
